### PR TITLE
Fix: wt: Crash when table file not found

### DIFF
--- a/scripts/playbtw_common.py
+++ b/scripts/playbtw_common.py
@@ -129,7 +129,7 @@ def read_wtable(table):
     elif os.path.exists(path3):
         path = path3
     else:
-        return [f'Weighted list not found: (%s) ' % table]
+        return [[1, f'Weighted list not found: (%s) ' % table]]
     with open(path, encoding='utf-8') as psvfile:
         spamreader = csv.reader(psvfile, delimiter='|', quotechar='"')
         for row in spamreader:


### PR DESCRIPTION
Before, running :wt.blah. would error out:

> [Espanso]: An error occurred during rendering, please examine the
> logs for more information.

With the logs reporting:

```
17:06:58 [worker(99822)] [WARN] script command exited with code: exit status: 1 and error: Traceback (most recent call last):
  File "playbtw_core.py", line 39, in <module>
  File "playbtw_common.py", line 161, in choice_wtable
ValueError: invalid literal for int() with base 10: 'W'
[53770] Failed to execute script 'playbtw_core' due to unhandled exception!

17:06:58 [worker(99822)] [WARN] extension 'script' on var: 'output' reported an error: script reported error: '`Traceback (most recent call last):
  File "playbtw_core.py", line 39, in <module>
  File "playbtw_common.py", line 161, in choice_wtable
ValueError: invalid literal for int() with base 10: 'W'
[53770] Failed to execute script 'playbtw_core' due to unhandled exception!
`'
17:06:58 [worker(99822)] [ERROR] error during rendering: rendering error

Caused by:
    script reported error: '`Traceback (most recent call last):
      File "playbtw_core.py", line 39, in <module>
      File "playbtw_common.py", line 161, in choice_wtable
    ValueError: invalid literal for int() with base 10: 'W'
    [53770] Failed to execute script 'playbtw_core' due to unhandled exception!
    `'
```

This proved to be due to the error case not matching the expected weighted table output format. Fixing it to look like a one-entry table with the error message as output gives the expected replacement text:

```
> env CONFIG=xxx python3 scripts/playbtw_core.py wtable --table blah
Weighted list not found: (blah)
```