### PR TITLE
Fix: :bway: Emits fixed solution "bold_waylay_solution" (sic)

### DIFF
--- a/tables/bold_waylays.txt
+++ b/tables/bold_waylays.txt
@@ -1,1 +1,1 @@
-The waylay: {{bold_waylay_modifier}} {{bold_waylay_noun}}. The solution: bold_waylay_solution
+The waylay: {{bold_waylay_modifier}} {{bold_waylay_noun}}. The solution: {{bold_waylay_solution}}


### PR DESCRIPTION
Before, :bway would always output the literal text `bold_waylay_solution` as the solution, e.g.:

> The waylay: hopeless Physical: labor. The solution: bold_waylay_solution

Now, a random solution drawn from the `bold_waylay_solution` table will be output, e.g.:

> The waylay: exclusive Knowledge: ascetic. The solution: strong attribute